### PR TITLE
Fix cross-sectional by implementing MRI QC, pipeline step 2

### DIFF
--- a/MRI/longitudinal_MRI_preproc_step1_indiviudal_preproc.m
+++ b/MRI/longitudinal_MRI_preproc_step1_indiviudal_preproc.m
@@ -270,7 +270,7 @@ for subI=sub_to_run(N)
                 continue 
             elseif isequal(max(anat_table.Order),1) && strcmpi(indMode{1}, 'off')
                 % no cross sectional data in avgmode
-                continue
+                continue 
             end
             if ~strcmpi(indMode{1}, 'all_times') && isnumeric(indMode{1}) && strcmp(avgMode, 'off')
                 % we're only processing some of the times
@@ -313,7 +313,7 @@ for subI=sub_to_run(N)
                 elseif strcmp(voxel_check, 'est only')
                     %coreg est only
                     mbatch = mbatch + 1;
-                    matlabbatch{mbatch}.spm.spatial.coreg.estimate.ref ={average_anat};
+                    matlabbatch{mbatch}.spm.spatial.coreg.estimate.ref ={coreg_image}; % AW changed this from 'average_anat' to 'coreg_image'. Not sure where the former was supposed to come from. 
                     matlabbatch{mbatch}.spm.spatial.coreg.estimate.source = {to_coreg};
                     matlabbatch{mbatch}.spm.spatial.coreg.estimate.other = {''};
                     matlabbatch{mbatch}.spm.spatial.coreg.estimate.eoptions.cost_fun = 'nmi';
@@ -534,7 +534,7 @@ for subI=sub_to_run(N)
             lorio_TPM = get_files(templatePath, 'enhanced_TPM.nii');
             mbatch=mbatch+1;
             %% run SPREAD segmentation routine. Make sure CAT12 default is to run in expert mode (see function below)
-            % (cat.extopts.expertgui    = 1;) in cat_default.m
+            % (cat.extopts.expertgui    = 1;) in cat_default.m % AW UPDATE: I found that this should actually be set to '2' (developer mode) for all settings to be found in CAT12. 
             for s=1:length(to_seg)
                 SPREAD_segmentation_routine(mbatch, to_seg{s}, lorio_TPM, CAT12_shoot_template, 0.5); % use processing accuracy of 0.5 to begin (default)
             end

--- a/run_longitudinal_preproc.m
+++ b/run_longitudinal_preproc.m
@@ -39,6 +39,8 @@ if strcmpi(image_modality, 'MRI')
     if ismember(step_to_run, {'dicomRecon', 'reorientAC', 'checkVoxels', 'coreg', 'longitudinalRegistration', 'segment'})
         longitudinal_MRI_preproc_step1_indiviudal_preproc(subs, study_path, mri_to_run, study_name, avgMode, indMode, ... 
         field_str, templatePath, CAT12_shoot_path,  coreg_image, step_to_run, 1)
+    elseif ismember(step_to_run, {'summarizeSegQC','redoSegProblems'})
+        longitudinal_MRI_preproc_step2_segQC(N, study_path, mri_to_run, study_name , qc_thresh, avgMode, indMode, field_str, templatePath, CAT12_shoot_path, step_to_run, 1)
     elseif ismember(step_to_run, {'buildCustomTemplate', 'addToShoot', 'invertY'})
         if ~isempty(shootTemplateOverride)
             longitudinal_MRI_preproc_step3_createTemplates(subs, study_path, mri_to_run, study_name, field_str, avgMode, indMode,step_to_run, 1, 'shootTemplateOverride', shootTemplateOverride)


### PR DESCRIPTION
Ran into a couple of bugs when running pipeline cross-sectionally. 
First, a small change: Step 1 needed to call coreg_image, instead of avg_image. 

Primary change is calling step 2 from main wrapper script, to enable MRI QC. Modified step 2 to read correct paths from setup file (in line with other steps). Throughout step 2 also renamed timepoint_IQR_fails to timepoint_fails, as this is what subsequent functions look for in the master spreadsheet.